### PR TITLE
updated readme, added request_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a simple tool to import Quandl datasets directly into Google Spreadsheet
 
 4. From the spreadsheet, choose the menu _Tools -> Script Editor_
 
-5. In the next dialog box: _Create Script for -> Spreadsheet_
+5. In the next dialog box: _Create Script for -> Google Sheets Add-on_
 
 6. Paste the code into window
 
@@ -29,6 +29,8 @@ This is a simple tool to import Quandl datasets directly into Google Spreadsheet
 9. Close the Script Editor tab and refresh your spreadsheet using F5 or CMD-R
 
 10. You will see a new menu after "Help", called "Quandl"
+
+11. Enter your auth token (found as "API key" at https://quandl.com/account): _Quandl -> Enter Auth Token_
 
 # Example Use
 
@@ -46,5 +48,5 @@ This is a simple tool to import Quandl datasets directly into Google Spreadsheet
 
 * If you enter your Auth Token, it will remain valid for six hours after your last request.
 
-* If you do not enter an Auth Token, the system will default to using no token. You may experience issues requesting excessive amounts of data without a valid token. 
+* If you do not enter an Auth Token, the system will default to using no token. This will most likely result in data not being downloaded as anonymous data access is limited.
 

--- a/quandl_google_spreadsheet_add_on.gs
+++ b/quandl_google_spreadsheet_add_on.gs
@@ -34,6 +34,7 @@ function readQuandlData() {
 	var domain = "www.quandl.com";
 	var api_version = "1";
 	var root_controller = "datasets";
+	var request_source = "googledocs";
 
 	// auth_token is stored in the cache
 	var cache = CacheService.getPrivateCache();
@@ -43,7 +44,7 @@ function readQuandlData() {
 	// only works with json right now
 	var format = "json";
 
-  var parameters = "?sort_order=desc";
+  var parameters = "?sort_order=desc&request_source=" + request_source;
 
   if (auth_token) {
 		// replace the auth_token in the cache

--- a/quandl_google_spreadsheet_add_on.gs
+++ b/quandl_google_spreadsheet_add_on.gs
@@ -169,8 +169,7 @@ function getQuandlCodesFromRangeValues(range_values) {
 function requestCodeFromUser() {
 
 	var ui = SpreadsheetApp.getUi();
-	var response = ui.prompt('Quandl Code Required', 'Please enter the Quandl code in the correct format (e.g. TAMMER1/SHIBOR) for the dataset you wish to load and then 
-click OK.', ui.ButtonSet.OK_CANCEL);
+	var response = ui.prompt('Quandl Code Required', 'Please enter the Quandl code in the correct format (e.g. TAMMER1/SHIBOR) for the dataset you wish to load and then click OK.', ui.ButtonSet.OK_CANCEL);
 	var quandl_code = response.getResponseText();
 
 	if (response.getSelectedButton() == ui.Button.OK && quandl_code) {


### PR DESCRIPTION
readme update:  as google doc calls originate from the google IP, this maxes out the anonymous data calls allowed by Quandl pretty quickly.  Thus, it is essentially required to use the auth token for this plug-in to function.

request_source:  added &request_sourse=googledocs to the api url.  This is in line with how Quandl identifies the requesting source (e.g. R, Python, etc.)
